### PR TITLE
Fix licence text in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ Now you'll have a sweet [matrix build on travis](https://travis-ci.org/imlucas/m
 
 ## License
 
-MIT
+Apache 2.0


### PR DESCRIPTION
`README.md` states `MIT` to be the license, although bot `LICENSE` and `package.json` state it to be `Apache 2.0`.