### PR TITLE
path error in error message fix 

### DIFF
--- a/bin/m.js
+++ b/bin/m.js
@@ -49,10 +49,12 @@ var abortIfError = function(err) {
     console.error('Try running your command again with debugging on:');
     console.error('   m ' + cmd + ' --debug');
     console.error();
-    console.error(chalk.bold('Stack Trace'));
-    err.stack.split('\n').map(function(line) {
-      console.error('  ', chalk.gray(line));
-    });
+    if (typeof err.stack !== 'undefined') {
+      console.error(chalk.bold('Stack Trace'));
+      err.stack.split('\n').map(function(line) {
+        console.error('  ', chalk.gray(line));
+      });
+    }
     return process.exit(1);
   }
 };


### PR DESCRIPTION
This provides a way for the errors to fail properly and not to fail on the failure of a missing err.stack