### PR TITLE
feat: Add node@4 to travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-  - 10.2.1
+  - 10
   - 8
   - 4
-before_install:
-  - npm i -g npm
 script:
   - npm test
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - 10.2.1
   - 8
+  - 4
 before_install:
   - npm i -g npm
 script:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "download": "^6.2.5",
     "figures": "^2.0.0",
     "fs-extra": "^4.0.2",
-    "get-mongodb-version": "^1.2.0",
+    "get-mongodb-version": "^2.0.0",
     "lodash.defaults": "^4.2.0",
     "lodash.difference": "^4.1.1",
     "mongodb-download-url": "^0.4.2",


### PR DESCRIPTION
The node.js driver still requires node@4 support and they use `mongodb-version-manager` for CI. If version-manager breaks on node@4, then @daprahamian and @mbroadst will have a bad day. So let's avoid that with some automation.

Also, upgrade get-mongodb-version to 2 fixes mongodb-js/runner#144