### PR TITLE
Fix download async.series calls

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -49,10 +49,18 @@ module.exports = function(model, done) {
     derived: true
   }));
   async.series([
-    fs.exists.bind(null, model.bin_directory),
+    function(cb) {
+      fs.stat(model.bin_directory, function(err) {
+        if (err) {
+          cb();
+        } else {
+          cb(new Error('already exists'));
+        }
+      });
+    },
     download.bind(null, model)
-  ], function(err) {
-    if (err === true) {
+  ], function(err, results) {
+    if (err && err.message === 'already exists') {
       debug('already have artifact at `%s`', model.bin_directory);
       return done();
     }


### PR DESCRIPTION
- Use fs.stat instead of fs.exists because the latter is deprecated
- Properly pass errors along. `fs.exists()` had an odd signature
  that was missing the typical Node.js `error` argument as its
  first position, and instead always called the callback with a
  single boolean.
  When the `async` package was updated to 3.x, this broke this
  functionality (and the tests), because it didn’t handle this
  “interpret a boolean as an error” hack well.
  Fix this by passing proper error objects to the callback.